### PR TITLE
update deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+# Use new container infrastructure to enable caching
+sudo: false
+
+# Choose a lightweight base image; we provide our own build tools.
+language: c
+
+# GHC depends on GMP. You can add other dependencies here as well.
+addons:
+  apt:
+    packages:
+    - libgmp-dev
+
+# The different configurations we want to test. You could also do things like
+# change flags or use --stack-yaml to point to a different file.
+env:
+- ARGS="--resolver=lts-2"
+- ARGS="--resolver=lts-3"
+- ARGS="--resolver=lts-4"
+- ARGS="--resolver=lts-5"
+- ARGS="--resolver=lts-6"
+- ARGS=""
+- ARGS="--resolver=nightly"
+
+before_install:
+# Download and unpack the stack executable
+- mkdir -p ~/.local/bin
+- export PATH=$HOME/.local/bin:$PATH
+- travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+
+# This line does all of the work: installs GHC if necessary, build the library,
+# executables, and test suites, and runs the test suites. --no-terminal works
+# around some quirks in Travis's terminal implementation.
+script:
+  - stack $ARGS setup
+  - stack $ARGS build --haddock --no-haddock-deps
+  - stack $ARGS sdist
+
+# Caching so the next build will be fast too.
+cache:
+  directories:
+  - $HOME/.stack

--- a/snap-accept.cabal
+++ b/snap-accept.cabal
@@ -30,8 +30,9 @@ library
 
   build-depends:
     base       >= 4.6.0 && < 5.0,
-    http-media >= 0.1.0 && < 0.2,
-    snap-core  >= 0.9.4 && < 0.14
+    http-media >= 0.4.0 && < 0.7,
+    snap-core  >= 0.9.4 && < 1.1,
+    bytestring
 
 source-repository head
   type:     git

--- a/src/Snap/Accept.hs
+++ b/src/Snap/Accept.hs
@@ -5,11 +5,12 @@ module Snap.Accept
     ) where
 
 ------------------------------------------------------------------------------
-import Control.Monad                (join, (>=>))
-import Data.Maybe                   (fromMaybe)
-import Network.HTTP.Media
-import Network.HTTP.Media.MediaType (toByteString)
-import Snap.Core
+import           Control.Monad                   (join, (>=>))
+import           Data.ByteString                 (ByteString)
+import           Data.Maybe                      (fromMaybe)
+import           Network.HTTP.Media
+import           Network.HTTP.Media.RenderHeader (renderHeader)
+import           Snap.Core
 
 
 ------------------------------------------------------------------------------
@@ -38,8 +39,8 @@ accepts dict = withAccept (mapAccept dict') >>= fromMaybe (snd $ head dict')
 ------------------------------------------------------------------------------
 -- | Parses the Accept header from the request and, if successful, passes
 -- it to the given function.
-withAccept :: MonadSnap m => ([Quality MediaType] -> Maybe a) -> m (Maybe a)
-withAccept f = getsRequest $ getHeader "Accept" >=> parseAccept >=> f
+withAccept :: MonadSnap m => (ByteString -> Maybe a) -> m (Maybe a)
+withAccept f = getsRequest $ getHeader "Accept" >=> f --TODO: when did parsequality show up
 
 
 ------------------------------------------------------------------------------
@@ -47,5 +48,5 @@ withAccept f = getsRequest $ getHeader "Accept" >=> parseAccept >=> f
 -- response's ContentType header.
 runWithType :: MonadSnap m => MediaType -> m a -> m a
 runWithType mtype action =
-    modifyResponse (setContentType $ toByteString mtype) >> action
+    modifyResponse (setContentType $ renderHeader mtype) >> action
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,6 @@
+resolver: lts-7.16
+packages:
+- '.'
+extra-deps: []
+flags: {}
+extra-package-dbs: []


### PR DESCRIPTION
This brings snap-accept into building with snap 1.0. I had to cut off http-media which has undergone some serious API changes since 0.1 but it still supports a pretty broad range.